### PR TITLE
Add support for NodeJs tests and improve error handling

### DIFF
--- a/TRX_Merger/Program.cs
+++ b/TRX_Merger/Program.cs
@@ -38,13 +38,13 @@ namespace TRX_Merger
                 return 1;
             }
 
-            bool excludePassedTests = false;
-            var includeExplicitTests = new List<string>();
-            string excludeExceptArg = args.Where(a => a.StartsWith("/excludePassedExcept")).FirstOrDefault();
+            bool excludeSuccessOutput = false;
+            var includeExplicitOutputTests = new List<string>();
+            string excludeExceptArg = args.Where(a => a.StartsWith("/excludeSuccessOuputExcept")).FirstOrDefault();
             if (!string.IsNullOrEmpty(excludeExceptArg))
             {
-                excludePassedTests = true;
-                includeExplicitTests = ResolveExplicitTestNames(excludeExceptArg);
+                excludeSuccessOutput = true;
+                includeExplicitOutputTests = ResolveExplicitTestNames(excludeExceptArg);
             }
 
             if (trxFiles.Count == 1)
@@ -109,7 +109,7 @@ namespace TRX_Merger
 
                 try
                 {
-                    var combinedTestRun = TestRunMerger.MergeTRXsAndSave(trxFiles, outputParam, excludePassedTests, includeExplicitTests);
+                    var combinedTestRun = TestRunMerger.MergeTRXsAndSave(trxFiles, outputParam, excludeSuccessOutput, includeExplicitOutputTests);
 
                     string reportOutput = ResolveReportLocation(args.Where(a => a.StartsWith("/report")).FirstOrDefault());
                     if (reportOutput == null)
@@ -272,10 +272,10 @@ PARAMETERS:
         {
             List<string> paths = new List<string>();
 
-            var hasNames = testNameParams.IndexOf("/excludePassedExcept:") > -1;
+            var hasNames = testNameParams.IndexOf("/excludeSuccessOuputExcept:") > -1;
             if (hasNames)
             {
-                var splitNames = testNameParams.Substring(21, testNameParams.Length - 21);
+                var splitNames = testNameParams.Substring(27, testNameParams.Length - 27);
                 if (!string.IsNullOrEmpty(splitNames))
                 {
                     paths = splitNames.Split(new char[] { ',' }).ToList();

--- a/TRX_Merger/Program.cs
+++ b/TRX_Merger/Program.cs
@@ -38,6 +38,15 @@ namespace TRX_Merger
                 return 1;
             }
 
+            bool excludePassedTests = false;
+            var includeExplicitTests = new List<string>();
+            string excludeExceptArg = args.Where(a => a.StartsWith("/excludePassedExcept")).FirstOrDefault();
+            if (!string.IsNullOrEmpty(excludeExceptArg))
+            {
+                excludePassedTests = true;
+                includeExplicitTests = ResolveExplicitTestNames(excludeExceptArg);
+            }
+
             if (trxFiles.Count == 1)
             {
                 if (trxFiles[0].StartsWith("Error: "))
@@ -100,7 +109,7 @@ namespace TRX_Merger
 
                 try
                 {
-                    var combinedTestRun = TestRunMerger.MergeTRXsAndSave(trxFiles, outputParam);
+                    var combinedTestRun = TestRunMerger.MergeTRXsAndSave(trxFiles, outputParam, excludePassedTests, includeExplicitTests);
 
                     string reportOutput = ResolveReportLocation(args.Where(a => a.StartsWith("/report")).FirstOrDefault());
                     if (reportOutput == null)
@@ -254,6 +263,23 @@ PARAMETERS:
                 if (isDir)
                     paths.AddRange(Directory.GetFiles(a, "*.trx", searchOpts).ToList());
 
+            }
+
+            return paths;
+        }
+
+        private static List<string> ResolveExplicitTestNames(string testNameParams)
+        {
+            List<string> paths = new List<string>();
+
+            var hasNames = testNameParams.IndexOf("/excludePassedExcept:") > -1;
+            if (hasNames)
+            {
+                var splitNames = testNameParams.Substring(21, testNameParams.Length - 21);
+                if (!string.IsNullOrEmpty(splitNames))
+                {
+                    paths = splitNames.Split(new char[] { ',' }).ToList();
+                }
             }
 
             return paths;

--- a/TRX_Merger/ReportModel/TestClassReport.cs
+++ b/TRX_Merger/ReportModel/TestClassReport.cs
@@ -27,7 +27,7 @@ namespace TRX_Merger.ReportModel
             Duration = new TimeSpan();
             durations.ForEach(d => Duration += d);
 
-            Dll = tests[0].Dll;
+            Dll = tests.FirstOrDefault()?.Dll;
         }
 
         public string TestClassName { get; set; }

--- a/TRX_Merger/TestRunMerger.cs
+++ b/TRX_Merger/TestRunMerger.cs
@@ -11,7 +11,7 @@ namespace TRX_Merger
     public static class TestRunMerger
     {
 
-        public static TestRun MergeTRXsAndSave(List<string> trxFiles, string outputFile, bool excludePassedTests, List<string> includeExplicitTests)
+        public static TestRun MergeTRXsAndSave(List<string> trxFiles, string outputFile, bool excludeSuccessOutput, List<string> includeExplicitOutputTests)
         {
             Console.WriteLine("Deserializing trx files:");
             List<TestRun> runs = new List<TestRun>();
@@ -22,10 +22,10 @@ namespace TRX_Merger
             }
 
             Console.WriteLine("Combining deserialized trx files...");
-            var combinedTestRun = MergeTestRuns(runs, excludePassedTests, includeExplicitTests);
+            var combinedTestRun = MergeTestRuns(runs);
 
             Console.WriteLine("Saving result...");
-            var savedFile = TRXSerializationUtils.SerializeAndSaveTestRun(combinedTestRun, outputFile);
+            var savedFile = TRXSerializationUtils.SerializeAndSaveTestRun(combinedTestRun, outputFile, excludeSuccessOutput, includeExplicitOutputTests);
 
             Console.WriteLine("Operation completed:");
             Console.WriteLine("\tCombined trx files: " + trxFiles.Count);
@@ -34,7 +34,7 @@ namespace TRX_Merger
             return combinedTestRun;
         }
 
-        private static TestRun MergeTestRuns(List<TestRun> testRuns, bool excludePassedTests, List<string> includeExplicitTests)
+        private static TestRun MergeTestRuns(List<TestRun> testRuns)
         {
             string name = testRuns[0].Name;
             string runUser = testRuns[0].RunUser;
@@ -63,8 +63,7 @@ namespace TRX_Merger
 
             foreach (var tr in testRuns)
             {
-                if (excludePassedTests) allResults = allResults.Concat(tr.Results.Where(c => c.Outcome != "Passed" || includeExplicitTests.Contains(c.TestName))).ToList();
-                else allResults = allResults.Concat(tr.Results).ToList();
+                allResults = allResults.Concat(tr.Results).ToList();
                 allTestDefinitions = allTestDefinitions.Concat(tr.TestDefinitions).ToList();
                 allTestEntries = allTestEntries.Concat(tr.TestEntries).ToList();
                 allTestLists = allTestLists.Concat(tr.TestLists).ToList();

--- a/TRX_Merger/TestRunMerger.cs
+++ b/TRX_Merger/TestRunMerger.cs
@@ -11,7 +11,7 @@ namespace TRX_Merger
     public static class TestRunMerger
     {
 
-        public static TestRun MergeTRXsAndSave(List<string> trxFiles, string outputFile)
+        public static TestRun MergeTRXsAndSave(List<string> trxFiles, string outputFile, bool excludePassedTests, List<string> includeExplicitTests)
         {
             Console.WriteLine("Deserializing trx files:");
             List<TestRun> runs = new List<TestRun>();
@@ -22,7 +22,7 @@ namespace TRX_Merger
             }
 
             Console.WriteLine("Combining deserialized trx files...");
-            var combinedTestRun = MergeTestRuns(runs);
+            var combinedTestRun = MergeTestRuns(runs, excludePassedTests, includeExplicitTests);
 
             Console.WriteLine("Saving result...");
             var savedFile = TRXSerializationUtils.SerializeAndSaveTestRun(combinedTestRun, outputFile);
@@ -34,7 +34,7 @@ namespace TRX_Merger
             return combinedTestRun;
         }
 
-        private static TestRun MergeTestRuns(List<TestRun> testRuns)
+        private static TestRun MergeTestRuns(List<TestRun> testRuns, bool excludePassedTests, List<string> includeExplicitTests)
         {
             string name = testRuns[0].Name;
             string runUser = testRuns[0].RunUser;
@@ -63,7 +63,8 @@ namespace TRX_Merger
 
             foreach (var tr in testRuns)
             {
-                allResults = allResults.Concat(tr.Results).ToList();
+                if (excludePassedTests) allResults = allResults.Concat(tr.Results.Where(c => c.Outcome != "Passed" || includeExplicitTests.Contains(c.TestName))).ToList();
+                else allResults = allResults.Concat(tr.Results).ToList();
                 allTestDefinitions = allTestDefinitions.Concat(tr.TestDefinitions).ToList();
                 allTestEntries = allTestEntries.Concat(tr.TestEntries).ToList();
                 allTestLists = allTestLists.Concat(tr.TestLists).ToList();

--- a/TRX_Merger/Utilities/TRXSerializationUtils.cs
+++ b/TRX_Merger/Utilities/TRXSerializationUtils.cs
@@ -11,7 +11,7 @@ namespace TRX_Merger.Utilities
         private static string ns = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}";
 
         #region Serializers
-        internal static string SerializeAndSaveTestRun(TestRun testRun, string targetPath)
+        internal static string SerializeAndSaveTestRun(TestRun testRun, string targetPath, bool excludeSuccessOutput, List<string> includeExplicitOutputTests)
         {
             XNamespace xmlns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
             XDocument doc =
@@ -40,7 +40,7 @@ namespace TRX_Merger.Utilities
                                         new XAttribute("testName", utr.TestName),
                                         new XAttribute("testType", utr.TestType),
                                         new XElement("Output",
-                                             utr.Output.StdOut == null ? null : new XElement("StdOut", utr.Output.StdOut),
+                                             GetStdOutElement(utr, excludeSuccessOutput, includeExplicitOutputTests),
                                              utr.Output.StdErr == null ? null : new XElement("StdErr", utr.Output.StdErr),
                                              utr.Output.ErrorInfo == null ? null :
                                              new XElement("ErrorInfo",
@@ -381,6 +381,17 @@ namespace TRX_Merger.Utilities
                 Start = xElement.Attribute("start").Value,
             };
         }
+
+        private static XElement GetStdOutElement(UnitTestResult utr, bool excludeSuccessOutput, List<string> includeExplicitOutputTests)
+        {
+            var includeOuput = !excludeSuccessOutput || utr.Outcome != "Passed" || includeExplicitOutputTests.Contains(utr.TestName);
+            if (utr.Output.StdOut != null && includeOuput)
+            {
+                return new XElement("StdOut", utr.Output.StdOut);
+            }
+            return null;
+        }
+
         #endregion
 
     }

--- a/TRX_Merger/Utilities/TRXSerializationUtils.cs
+++ b/TRX_Merger/Utilities/TRXSerializationUtils.cs
@@ -52,7 +52,7 @@ namespace TRX_Merger.Utilities
                                 td => new XElement("UnitTest",
                                          new XAttribute("id", td.Id),
                                          new XAttribute("name", td.Name),
-                                         new XAttribute("storage", td.Storage),
+                                         new XAttribute("storage", td.Storage ?? ""),
                                          new XElement("Execution",
                                             new XAttribute("id", td.Execution.Id)),
                                          new XElement("TestMethod",


### PR DESCRIPTION
### Summary of changes

This PR introduces several fixes, which are:

- [x] When creating a report, if the tests are for a particular test class are empty, the report does not render
- [x] When including NodeJs tests, the merge fails as the NodeJs tests dont have an underlying DLL and the code assumes they do which then causes an exception
- [x] The combined merge file can get quite sizable when it includes output for passed as well as failed tests, introduced a new command line option to only include StdOut for failed tests or explicitly named tests to the results to reduce the size